### PR TITLE
feat: add new LEMMY_DOMAIN_INTERNAL for overriding container destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ LEMMY_DOMAIN='lemmy.world' ./mlmym --addr :8080
 
 This mode provides a dedicated frontend for a specific Lemmy instance.
 
+#### 🔧 Internal Domain Override
+When running mlmym in a container environment, you may want API calls to go directly to the Lemmy container instead of through the public domain. Set `LEMMY_DOMAIN_INTERNAL` to override the API endpoint while keeping `LEMMY_DOMAIN` for user-facing URLs.
+
+```bash
+# Docker Compose example - mlmym talks directly to lemmy container
+docker run -it \
+  -e LEMMY_DOMAIN='lemmy.world' \
+  -e LEMMY_DOMAIN_INTERNAL='http://lemmy:8536' \
+  -p "8080:8080" \
+  ghcr.io/fedihosting-foundation-forks/mlmym:latest
+```
+
+This enables the traffic flow: `User → webserver → mlmym → lemmy` instead of `User → webserver → mlmym → webserver → lemmy`.
+
+**Note:** `LEMMY_DOMAIN_INTERNAL` only works when `LEMMY_DOMAIN` is also set (single instance mode).
+
 ### 🎨 Default User Settings
 
 Customize the default experience for all users by setting these environment variables:

--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ LEMMY_DOMAIN='lemmy.world' ./mlmym --addr :8080
 
 This mode provides a dedicated frontend for a specific Lemmy instance.
 
-#### 🔧 Internal Domain Override
-When running mlmym in a container environment, you may want API calls to go directly to the Lemmy container instead of through the public domain. Set `LEMMY_DOMAIN_INTERNAL` to override the API endpoint while keeping `LEMMY_DOMAIN` for user-facing URLs.
+#### 🔧 Internal URL Override
+When running mlmym in a container environment, you may want API calls to go directly to the Lemmy container instead of through the public domain. Set `LEMMY_INTERNAL_URL` to override the API endpoint while keeping `LEMMY_DOMAIN` for user-facing URLs.
 
 ```bash
 # Docker Compose example - mlmym talks directly to lemmy container
 docker run -it \
   -e LEMMY_DOMAIN='lemmy.world' \
-  -e LEMMY_DOMAIN_INTERNAL='http://lemmy:8536' \
+  -e LEMMY_INTERNAL_URL='http://lemmy:8536' \
   -p "8080:8080" \
   ghcr.io/fedihosting-foundation-forks/mlmym:latest
 ```
 
 This enables the traffic flow: `User → webserver → mlmym → lemmy` instead of `User → webserver → mlmym → webserver → lemmy`.
 
-**Note:** `LEMMY_DOMAIN_INTERNAL` only works when `LEMMY_DOMAIN` is also set (single instance mode).
+**Note:** `LEMMY_INTERNAL_URL` only works when `LEMMY_DOMAIN` is also set (single instance mode).
 
 ### 🎨 Default User Settings
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ var addr = flag.String("addr", ":80", "http service address")
 var md goldmark.Markdown
 var templates map[string]*template.Template
 
+var lemmyDomain string
+var lemmyInternalURL string
+
 type AddHeaderTransport struct {
 	T          http.RoundTripper
 	ForwardFor string
@@ -53,6 +56,10 @@ func NewAddHeaderTransport(remoteAddr string) *AddHeaderTransport {
 }
 
 func init() {
+	lemmyDomain = os.Getenv("LEMMY_DOMAIN")
+	if lemmyDomain != "" {
+		lemmyInternalURL = os.Getenv("LEMMY_INTERNAL_URL")
+	}
 	md = goldmark.New(goldmark.WithExtensions(
 		extension.Linkify,
 		extension.Table,

--- a/routes.go
+++ b/routes.go
@@ -43,8 +43,8 @@ var isImage = func(u string) bool {
 
 var funcMap = template.FuncMap{
 	"host": func(host string) string {
-		if l := os.Getenv("LEMMY_DOMAIN"); l != "" {
-			return l
+		if lemmyDomain != "" {
+			return lemmyDomain
 		}
 		return host
 	},
@@ -289,7 +289,6 @@ func Initialize(Host string, r *http.Request) (State, error) {
 	if watch != nil {
 		state.Watch = *watch
 	}
-	lemmyDomain := os.Getenv("LEMMY_DOMAIN")
 	if lemmyDomain != "" {
 		state.Host = "."
 		Host = lemmyDomain
@@ -299,10 +298,11 @@ func Initialize(Host string, r *http.Request) (State, error) {
 		remoteAddr = r.Header.Get("CF-Connecting-IP")
 	}
 	client := http.Client{Transport: NewAddHeaderTransport(remoteAddr)}
-	// Use internal domain for API calls if configured, otherwise use public domain
-	apiHost := "https://" + Host
-	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && lemmyDomain != "" {
-		apiHost = internalDomain
+	var apiHost string
+	if lemmyInternalURL != "" {
+		apiHost = lemmyInternalURL
+	} else {
+		apiHost = "https://" + Host
 	}
 	c, err := lemmy.NewWithClient(apiHost, &client)
 	if err != nil {
@@ -446,9 +446,11 @@ type NodeInfo struct {
 func IsLemmy(domain string, remoteAddr string) bool {
 	client := http.Client{Transport: NewAddHeaderTransport(remoteAddr)}
 	var nodeInfo NodeInfo
-	apiURL := "https://" + domain + "/nodeinfo/2.0.json"
-	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && domain == os.Getenv("LEMMY_DOMAIN") {
-		apiURL = internalDomain + "/nodeinfo/2.0.json"
+	var apiURL string
+	if lemmyInternalURL != "" && domain == lemmyDomain {
+		apiURL = lemmyInternalURL + "/nodeinfo/2.0.json"
+	} else {
+		apiURL = "https://" + domain + "/nodeinfo/2.0.json"
 	}
 	res, err := client.Get(apiURL)
 	if err != nil {
@@ -575,9 +577,11 @@ func ResolveId(r *http.Request, class string, id string, host string) string {
 		remoteAddr = r.Header.Get("CF-Connecting-IP")
 	}
 	client := http.Client{Transport: NewAddHeaderTransport(remoteAddr)}
-	apiHost := "https://" + host
-	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && os.Getenv("LEMMY_DOMAIN") != "" {
-		apiHost = internalDomain
+	var apiHost string
+	if lemmyInternalURL != "" {
+		apiHost = lemmyInternalURL
+	} else {
+		apiHost = "https://" + host
 	}
 	c, err := lemmy.NewWithClient(apiHost, &client)
 	if err != nil {
@@ -618,7 +622,7 @@ func GetPost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			})
 			if err != nil {
 				dest := apid
-				if os.Getenv("LEMMY_DOMAIN") == "" {
+				if lemmyDomain == "" {
 					dest = RegReplace(dest, `https:\/\/([a-zA-Z0-9\.\-]+\/post\/\d+)`, `/$1`)
 				}
 				http.Redirect(w, r, dest, http.StatusFound)
@@ -672,7 +676,7 @@ func GetComment(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			})
 			if err != nil {
 				dest := apid
-				if os.Getenv("LEMMY_DOMAIN") == "" {
+				if lemmyDomain == "" {
 					dest = RegReplace(dest, `https:\/\/([a-zA-Z0-9\.\-]+\/comment\/\d+)`, `/$1`)
 				}
 				http.Redirect(w, r, dest, http.StatusFound)
@@ -1115,7 +1119,7 @@ func UserOp(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	}
 	host := state.Host
 	if host == "." {
-		host = os.Getenv("LEMMY_DOMAIN")
+		host = lemmyDomain
 	}
 	switch r.FormValue("op") {
 	case "leave":
@@ -1714,9 +1718,9 @@ func GetLink(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		http.Redirect(w, r, redirect, http.StatusFound)
 		return
 	}
-	if host := os.Getenv("LEMMY_DOMAIN"); host != "" {
+	if lemmyDomain != "" {
 		redirect := dest.Path
-		if host != dest.Host && !strings.Contains(redirect, "@") {
+		if lemmyDomain != dest.Host && !strings.Contains(redirect, "@") {
 			redirect += ("@" + dest.Host)
 		}
 		http.Redirect(w, r, redirect, http.StatusFound)
@@ -1724,9 +1728,8 @@ func GetLink(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	}
 }
 func GetRouter() *httprouter.Router {
-	host := os.Getenv("LEMMY_DOMAIN")
 	router := httprouter.New()
-	if host == "" {
+	if lemmyDomain == "" {
 		router.ServeFiles("/:host/static/*filepath", http.Dir("public"))
 		router.GET("/", GetRoot)
 		router.POST("/", PostRoot)

--- a/state.go
+++ b/state.go
@@ -268,7 +268,11 @@ func (state *State) ParseQuery(RawQuery string) {
 
 func (state *State) LemmyError(domain string) error {
 	var nodeInfo NodeInfo
-	res, err := state.HTTPClient.Get("https://" + domain + "/nodeinfo/2.0.json")
+	apiURL := "https://" + domain + "/nodeinfo/2.0.json"
+	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && domain == os.Getenv("LEMMY_DOMAIN") {
+		apiURL = internalDomain + "/nodeinfo/2.0.json"
+	}
+	res, err := state.HTTPClient.Get(apiURL)
 	if err != nil {
 		return err
 	}
@@ -757,7 +761,11 @@ func (state *State) UploadImage(file multipart.File, header *multipart.FileHeade
 	if host == "." {
 		host = os.Getenv("LEMMY_DOMAIN")
 	}
-	req, err := http.NewRequest("POST", "https://"+host+"/pictrs/image", body)
+	apiURL := "https://" + host + "/pictrs/image"
+	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && os.Getenv("LEMMY_DOMAIN") != "" {
+		apiURL = internalDomain + "/pictrs/image"
+	}
+	req, err := http.NewRequest("POST", apiURL, body)
 	if err != nil {
 		return nil, err
 	}

--- a/state.go
+++ b/state.go
@@ -12,7 +12,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -138,7 +137,7 @@ func (s State) Unknown() string {
 		}
 		if matches[0][2] != s.Host {
 			remote := "/" + matches[0][2] + "/c/" + matches[0][1]
-			if os.Getenv("LEMMY_DOMAIN") != "" {
+			if lemmyDomain != "" {
 				remote = "https:/" + remote
 			}
 			return remote
@@ -151,7 +150,7 @@ func (s State) Unknown() string {
 		}
 		if matches[0][2] != s.Host {
 			remote := "/" + matches[0][2] + "/u/" + matches[0][1]
-			if os.Getenv("LEMMY_DOMAIN") != "" {
+			if lemmyDomain != "" {
 				remote = "https:/" + remote
 			}
 			return remote
@@ -268,9 +267,11 @@ func (state *State) ParseQuery(RawQuery string) {
 
 func (state *State) LemmyError(domain string) error {
 	var nodeInfo NodeInfo
-	apiURL := "https://" + domain + "/nodeinfo/2.0.json"
-	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && domain == os.Getenv("LEMMY_DOMAIN") {
-		apiURL = internalDomain + "/nodeinfo/2.0.json"
+	var apiURL string
+	if lemmyInternalURL != "" && domain == lemmyDomain {
+		apiURL = lemmyInternalURL + "/nodeinfo/2.0.json"
+	} else {
+		apiURL = "https://" + domain + "/nodeinfo/2.0.json"
 	}
 	res, err := state.HTTPClient.Get(apiURL)
 	if err != nil {
@@ -759,11 +760,13 @@ func (state *State) UploadImage(file multipart.File, header *multipart.FileHeade
 	writer.Close()
 	host := state.Host
 	if host == "." {
-		host = os.Getenv("LEMMY_DOMAIN")
+		host = lemmyDomain
 	}
-	apiURL := "https://" + host + "/pictrs/image"
-	if internalDomain := os.Getenv("LEMMY_DOMAIN_INTERNAL"); internalDomain != "" && os.Getenv("LEMMY_DOMAIN") != "" {
-		apiURL = internalDomain + "/pictrs/image"
+	var apiURL string
+	if lemmyInternalURL != "" {
+		apiURL = lemmyInternalURL + "/pictrs/image"
+	} else {
+		apiURL = "https://" + host + "/pictrs/image"
 	}
 	req, err := http.NewRequest("POST", apiURL, body)
 	if err != nil {


### PR DESCRIPTION
Live on https://old.reddthat.com

Seems to work great. 

If they are not in the same docker-compose stacks you also need to ensure they are on the same network but I think that is not needed to be said for regular deployments. 